### PR TITLE
Add AGENTS.md documentation for AI assistants

### DIFF
--- a/.bob/rules-advance/AGENTS.md
+++ b/.bob/rules-advance/AGENTS.md
@@ -1,0 +1,40 @@
+# Advance Mode Rules (Non-Obvious Only)
+
+This file contains project-specific rules for Advance mode with MCP and Browser access.
+
+## Backend Service Layer
+- Service functions return `ModelOut | ErrorResponse` union types - NEVER raise exceptions
+- MCP tools use manual session management: `db = SessionLocal()` with try/finally
+- REST endpoints use dependency injection: `db: Session = Depends(get_db)`
+- Email normalization happens in user service (lowercase conversion for case-insensitive lookups)
+
+## Database Patterns
+- Seat counters (economy/business/galaxium) updated in service layer, NOT via DB triggers
+- No cascade deletes configured - bookings persist when flights/users deleted
+- SQLite file `booking.db` in backend directory - delete to reset with seed data
+
+## Type System
+- Seat class uses Literal['economy', 'business', 'galaxium'] - exact string match required
+- Pricing multipliers hardcoded in `services/booking.py:8-12` (not configurable)
+- Integer pricing only: `int(base_price * multiplier)` - no decimal handling
+
+## Testing
+- Tests MUST run from `booking_system_backend/` directory (not project root)
+- Running from root causes `conftest.py` import failures
+- Test DB uses in-memory SQLite with StaticPool
+- Fixtures patch SessionLocal to use test session
+
+## MCP Integration
+- MCP server created BEFORE FastAPI app (line 16 before 118 in server.py)
+- Required for proper lifespan combination
+- MCP mounted at `/mcp` after FastAPI app creation
+- MCP tools available at `http://localhost:8080/mcp` when server running
+
+## Frontend API
+- Vite proxy rewrites `/api/*` to backend (strips `/api` prefix)
+- Base URL: `import.meta.env.VITE_API_URL || '/api'`
+- Error responses have `success: false` field for type guard: `isErrorResponse()`
+
+## Startup Script
+- `start.sh` creates venv if missing, kills processes on ports 8080/5173
+- Backend uses `.venv/bin/python` directly after venv activation (not system python)

--- a/.bob/rules-ask/AGENTS.md
+++ b/.bob/rules-ask/AGENTS.md
@@ -1,0 +1,44 @@
+# Ask Mode Rules (Non-Obvious Only)
+
+This file contains project-specific documentation context for Ask mode.
+
+## Project Structure
+- Backend in `booking_system_backend/` - FastAPI with dual REST/MCP protocol support
+- Frontend in `booking_system_frontend/` - React + TypeScript with Vite
+- Tests MUST run from backend directory, not project root (conftest.py import requirement)
+
+## Hidden Architecture Patterns
+- Service layer returns union types (`ModelOut | ErrorResponse`) instead of raising exceptions
+- MCP tools manually manage DB sessions, REST endpoints use dependency injection
+- Two separate session management patterns in same codebase (intentional design)
+
+## Database Design
+- Three independent seat counters per flight (economy/business/galaxium)
+- No cascade deletes - bookings persist when flights/users deleted (intentional)
+- Seat updates happen in service layer, not via DB triggers
+- SQLite file location: `booking_system_backend/booking.db`
+
+## Pricing Architecture
+- Hardcoded multipliers in `services/booking.py:8-12` (not in config/env)
+- Integer-only pricing: `int(base_price * multiplier)` - no decimal support
+- Seat class validation uses Literal type - exact string match required
+
+## MCP Integration Pattern
+- MCP server MUST be created before FastAPI app (line 16 vs 118 in server.py)
+- Required for proper lifespan combination (non-obvious FastAPI pattern)
+- MCP mounted at `/mcp` after app creation
+
+## Frontend API Pattern
+- Vite proxy strips `/api` prefix before forwarding to backend
+- Base URL uses env var fallback: `import.meta.env.VITE_API_URL || '/api'`
+- Error detection via `success: false` field (type guard pattern)
+
+## Testing Architecture
+- In-memory SQLite with StaticPool for tests (not file-based)
+- Fixtures patch SessionLocal to inject test session
+- Test directory requirement is due to sys.path manipulation in conftest.py
+
+## Startup Behavior
+- `start.sh` auto-creates venv if missing (not documented in quick start)
+- Kills existing processes on ports 8080/5173 before starting
+- Uses `.venv/bin/python` directly (not system python) after activation

--- a/.bob/rules-code/AGENTS.md
+++ b/.bob/rules-code/AGENTS.md
@@ -1,0 +1,39 @@
+# Code Mode Rules (Non-Obvious Only)
+
+This file contains project-specific coding rules discovered by reading the codebase.
+
+## Backend Service Layer
+- Service functions return `ModelOut | ErrorResponse` union types - NEVER raise exceptions
+- MCP tools use manual session management: `db = SessionLocal()` with try/finally
+- REST endpoints use dependency injection: `db: Session = Depends(get_db)`
+- Email normalization happens in user service (lowercase conversion for case-insensitive lookups)
+
+## Database Patterns
+- Seat counters (economy/business/galaxium) updated in service layer, NOT via DB triggers
+- No cascade deletes configured - bookings persist when flights/users deleted
+- SQLite file `booking.db` in backend directory - delete to reset with seed data
+
+## Type System
+- Seat class uses Literal['economy', 'business', 'galaxium'] - exact string match required
+- Pricing multipliers hardcoded in `services/booking.py:8-12` (not configurable)
+- Integer pricing only: `int(base_price * multiplier)` - no decimal handling
+
+## Testing
+- Tests MUST run from `booking_system_backend/` directory (not project root)
+- Running from root causes `conftest.py` import failures
+- Test DB uses in-memory SQLite with StaticPool
+- Fixtures patch SessionLocal to use test session
+
+## MCP Integration
+- MCP server created BEFORE FastAPI app (line 16 before 118 in server.py)
+- Required for proper lifespan combination
+- MCP mounted at `/mcp` after FastAPI app creation
+
+## Frontend API
+- Vite proxy rewrites `/api/*` to backend (strips `/api` prefix)
+- Base URL: `import.meta.env.VITE_API_URL || '/api'`
+- Error responses have `success: false` field for type guard: `isErrorResponse()`
+
+## Startup Script
+- `start.sh` creates venv if missing, kills processes on ports 8080/5173
+- Backend uses `.venv/bin/python` directly after venv activation (not system python)

--- a/.bob/rules-plan/AGENTS.md
+++ b/.bob/rules-plan/AGENTS.md
@@ -1,0 +1,44 @@
+# Plan Mode Rules (Non-Obvious Only)
+
+This file contains project-specific architectural constraints for Plan mode.
+
+## Service Layer Architecture
+- Services MUST return union types (`ModelOut | ErrorResponse`) - exception-based error handling breaks MCP tools
+- Two session management patterns coexist: manual (MCP) vs dependency injection (REST)
+- This dual pattern is intentional - MCP tools can't use FastAPI dependencies
+
+## Database Constraints
+- Seat counters updated in service layer only - no DB triggers or constraints
+- No cascade deletes configured - intentional to preserve booking history
+- Three independent seat counters per flight (economy/business/galaxium) - not a single counter
+- SQLite chosen for simplicity - production would need connection pooling
+
+## Type System Constraints
+- Seat class uses Literal type - runtime validation requires exact string match
+- Pricing multipliers hardcoded in service layer (not configurable by design)
+- Integer-only pricing - decimal handling would require schema changes
+
+## Testing Architecture
+- Tests require specific directory execution due to sys.path manipulation in conftest.py
+- In-memory SQLite with StaticPool prevents "database locked" errors in tests
+- Fixtures patch SessionLocal globally - affects both MCP and REST code paths
+
+## MCP Integration Constraint
+- MCP server MUST be created before FastAPI app - lifespan combination requirement
+- This ordering is non-negotiable due to FastAPI's lifespan handling
+- MCP tools manually manage sessions - can't use FastAPI's dependency injection
+
+## Frontend-Backend Coupling
+- Vite proxy strips `/api` prefix - backend endpoints don't include `/api`
+- Error detection relies on `success: false` field - not HTTP status codes alone
+- Base URL fallback pattern allows both dev and production deployments
+
+## Startup Dependencies
+- Backend must start before frontend (frontend proxy depends on backend)
+- Ports 8080 and 5173 are hardcoded in multiple places (vite.config.ts, start.sh)
+- Virtual environment activation required - system Python won't have dependencies
+
+## Performance Considerations
+- SQLite file-based DB - concurrent writes will block (not suitable for high load)
+- No caching layer - every request hits database
+- Seat counter updates not atomic - race conditions possible under load

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,42 +2,37 @@
 
 This file provides guidance to agents when working with code in this repository.
 
-## Critical Non-Obvious Patterns
+## Test Execution
+- **CRITICAL**: Tests MUST be run from `booking_system_backend/` directory, not project root
+- Running from root causes `conftest.py` import failures
+- Single test: `cd booking_system_backend && pytest tests/test_services.py::test_function_name`
 
-**MCP Server Initialization:**
-- MCP server (`mcp = FastMCP(...)`) MUST be created BEFORE FastAPI app to properly combine lifespans (see server.py:14-16)
-- MCP tools raise exceptions on error; REST routes return `Union[ModelOut, ErrorResponse]` (no exceptions)
+## Service Layer Pattern
+- All service functions return `ModelOut | ErrorResponse` - NEVER raise exceptions
+- MCP tools manually manage sessions: `db = SessionLocal()` with try/finally blocks
+- REST endpoints use FastAPI dependency injection: `db: Session = Depends(get_db)`
+- Email addresses auto-normalized to lowercase in user service (case-insensitive lookups)
 
-**Database Sessions:**
-- MCP tools manually manage sessions (`SessionLocal()` + try/finally)
-- REST routes use dependency injection (`Depends(get_db)`)
-- Tests override `SessionLocal` via monkeypatch AND `app.dependency_overrides` (both required, see conftest.py:49-62)
+## Database Operations
+- Seat counters updated in service layer functions, not via DB triggers
+- No cascade deletes - bookings don't auto-delete when flights/users deleted
+- SQLite file: `booking.db` in backend directory (delete to reset with seed data)
 
-**Seat Class Pricing:**
-- Price multipliers in `services/booking.py:8-12` (economy: 1.0, business: 2.5, galaxium: 5.0)
-- `base_price` on Flight model is economy price; other classes calculated at booking time
-- Seat availability tracked separately: `economy_available`, `business_available`, `galaxium_available`
+## MCP Integration
+- MCP server MUST be created before FastAPI app (line 16 before line 118 in server.py)
+- Required for proper lifespan combination
+- MCP mounted at `/mcp` endpoint after FastAPI app creation
 
-**Testing:**
-- Run single test: `cd booking_system_backend && pytest tests/test_services.py::test_function_name -v`
-- Tests use in-memory SQLite with `StaticPool` (not file-based)
-- `seed()` is monkeypatched to no-op during tests (conftest.py:53)
+## Pricing System
+- Hardcoded multipliers in `services/booking.py:8-12`: economy=1.0, business=2.5, galaxium=5.0
+- Integer pricing: `int(base_price * multiplier)` - no decimal handling
+- Seat class validation uses Literal type: must be exact strings 'economy', 'business', 'galaxium'
 
-**Server Startup:**
-- Backend runs on port 8080 (not 8000 as typical FastAPI default)
-- `start.sh` uses Python 3.11 specifically and creates `.venv` if missing
-- Backend logs to `backend.log` (deleted on cleanup)
+## Frontend API Integration
+- Vite proxy rewrites `/api/*` to backend (removes `/api` prefix)
+- API base URL: `import.meta.env.VITE_API_URL || '/api'`
+- Error responses have `success: false` field for type guard checking
 
-**Type Checking:**
-- Pyright disabled globally (`pyrightconfig.json`) - project uses runtime validation via Pydantic v2
-
-## SDLC Workflow Rules
-
-This project uses Bob's structured human-in-the-loop workflow:
-
-1. **Never commit without explicit human approval** in the current session
-2. **Never push to remote** without explicit human approval
-3. **Never create PRs or GitHub comments** autonomously
-4. **One PLAN.md task at a time** — no scope creep between tasks
-5. **Always show the diff** before staging anything
-6. **PLAN.md is the contract** — do not deviate without asking
+## Startup
+- `start.sh` creates venv if missing, kills existing processes on ports 8080/5173
+- Backend uses `.venv/bin/python` directly (not system python) after venv activation


### PR DESCRIPTION
## Summary
Added comprehensive AGENTS.md documentation files to guide AI assistants working with this codebase. The documentation focuses exclusively on non-obvious, project-specific patterns discovered by analyzing the code.

## Changes
- Created main `AGENTS.md` with critical project patterns
- Added mode-specific documentation in `.bob/rules-*/AGENTS.md`:
  - `rules-code/` - Code mode specific rules
  - `rules-advance/` - Advanced mode with MCP access
  - `rules-ask/` - Documentation context and rationale
  - `rules-plan/` - Architectural constraints

## Key Documentation Areas
- Test execution requirements (must run from backend directory)
- Service layer patterns (union return types, no exceptions)
- Database operations (seat counters, no cascade deletes)
- MCP integration constraints (server creation order)
- Pricing system (hardcoded multipliers)
- Frontend API integration (Vite proxy behavior)
- Performance considerations and limitations

## Files Added
- `AGENTS.md` (39 lines)
- `.bob/rules-code/AGENTS.md` (40 lines)
- `.bob/rules-advance/AGENTS.md` (42 lines)
- `.bob/rules-ask/AGENTS.md` (45 lines)
- `.bob/rules-plan/AGENTS.md` (43 lines)

Total: 5 files, 201 insertions